### PR TITLE
Force a font size apply from settings if initial line matches

### DIFF
--- a/demo/template.html
+++ b/demo/template.html
@@ -11,7 +11,7 @@
 </head>
 
 <body>
-    <div id="mounthere" style="width: 200px;line-height: 2; border:1px solid red; font-size: 28px"></div>
+    <div id="mounthere" style="width: 200px;line-height: 2; border:1px solid red; font-size: 12px"></div>
 </body>
 
 </html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "auto-fontsize",
-    "version": "1.0.11",
+    "version": "1.0.12",
     "description": "Auto resize font to fit the parent container width",
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",

--- a/src/AutoFontSize.tsx
+++ b/src/AutoFontSize.tsx
@@ -30,7 +30,7 @@ interface IAutoFontSizeStates {
 class AutoFontSize extends React.Component<
   IAutoFontSizeProps,
   IAutoFontSizeStates
-> {
+  > {
   public static defaultProps: Partial<IAutoFontSizeProps> = {
     textSizeStep: 2,
     targetLines: 1,
@@ -81,7 +81,9 @@ class AutoFontSize extends React.Component<
       const lineHeight = lineHeightFunc(container);
       const containerHeight = container.clientHeight;
       const currentTextLines = Math.floor(containerHeight / lineHeight);
-      if (currentTextLines > targetLines && currentTextLines > minTextSize) {
+
+      // !!!currentTextSize triggers a update anyway to ignore parent container inherit
+      if (!!!currentTextSize || (currentTextLines > targetLines && currentTextLines > minTextSize)) {
         const { fontSizeMapping } = this.props;
         // do auto sizing
         if (fontSizeMapping && fontSizeMapping.length) {


### PR DESCRIPTION
In case of:
target line set to 'x', the initial line created is 'x' too, but the font may different from the setting value, this change is to ask the component to force respect the font size settings.